### PR TITLE
fix issues with duplicate internal TF names

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 This Terraform module is responsible for provisioning CloudSploit IAM resources(IAM trust/roles).
 
-This module is considered a *Global* module and only needs to be provisioned 1 time per AWS Account. 
+This module is considered a *Global* module and only needs to be provisioned 1 time per AWS Account.
 
 ## Incorporating this Module
 * Add this code to your provider file
 * The **account_id** must be set & passed from the root module.
 * The **cloudsploit_external_id** must be obtained from CloudSploit and different AWS accounts have different external IDs.
+* The **use_aws_gov** can be set to a boolean value, it defaults to `false`
 
 ```
 module "cloudsploit" {

--- a/README.md
+++ b/README.md
@@ -19,4 +19,5 @@ module "cloudsploit" {
 ```
 
 ## Outputs
-* **cloudsploit_cross_account_role_arn** - Cloudsploit cross account trust role.
+* **cloudsploit_cross_account_role_arn** - Cloudsploit cross account trust role. This is only output if `use_aws_gov` is set to `true`.
+* **cloudsploit_cross_account_role_gov_arn** - Cloudsploit cross account trust role for AWS gov. This is only output if `use_aws_gov` is set to `false`.

--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ module "cloudsploit" {
 ```
 
 ## Outputs
-* **cloudsploit_cross_account_role_arn** - Cloudsploit cross account trust role. This is only output if `use_aws_gov` is set to `true`.
-* **cloudsploit_cross_account_role_gov_arn** - Cloudsploit cross account trust role for AWS gov. This is only output if `use_aws_gov` is set to `false`.
+* **cloudsploit_cross_account_role_arn** - Cloudsploit cross account trust role. This is only output if `use_aws_gov` is set to `false`.
+* **cloudsploit_cross_account_role_arn-gov** - Cloudsploit cross account trust role for AWS gov. This is only output if `use_aws_gov` is set to `true`.

--- a/iam_cloudsploit_role.tf
+++ b/iam_cloudsploit_role.tf
@@ -1,6 +1,9 @@
 resource "aws_iam_role" "cloudsploit_cross_account_role" {
   name = "tf-cloudsploit"
 
+  # disable this if use_aws_gov == true
+  count = "${var.use_aws_gov ? 0 : 1}"
+
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -23,6 +26,9 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "cloudsploit_cross_account_attach" {
+  # disable this if use_aws_gov == true
+  count = "${var.use_aws_gov ? 0 : 1}"
+
   role       = "${aws_iam_role.cloudsploit_cross_account_role.name}"
   policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
 }

--- a/iam_cloudsploit_role_gov.tf
+++ b/iam_cloudsploit_role_gov.tf
@@ -1,5 +1,8 @@
-resource "aws_iam_role" "cloudsploit_cross_account_role" {
+resource "aws_iam_role" "cloudsploit_cross_account_role-gov" {
   name = "tf-cloudsploit"
+
+  # enable this if use_aws_gov == true
+  count = "${var.use_aws_gov ? 1 : 0}"
 
   assume_role_policy = <<EOF
 {
@@ -22,7 +25,10 @@ resource "aws_iam_role" "cloudsploit_cross_account_role" {
 EOF
 }
 
-resource "aws_iam_role_policy_attachment" "cloudsploit_cross_account_attach" {
-  role       = "${aws_iam_role.cloudsploit_cross_account_role.name}"
+resource "aws_iam_role_policy_attachment" "cloudsploit_cross_account_attach-gov" {
+  # enable this if use_aws_gov == true
+  count = "${var.use_aws_gov ? 1 : 0}"
+
+  role       = "${aws_iam_role.cloudsploit_cross_account_role-gov.name}"
   policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
 }

--- a/output.tf
+++ b/output.tf
@@ -1,7 +1,13 @@
 output "cloudsploit_cross_account_role_arn" {
-  value = "${aws_iam_role.cloudsploit_cross_account_role.arn}"
+  value = "${aws_iam_role.cloudsploit_cross_account_role.*.arn}"
+
+  # disable output for this resource if we are using aws gov
+  count = "${var.use_aws_gov ? 0 : 1}"
 }
 
 output "cloudsploit_cross_account_role_arn-gov" {
-  value = "${aws_iam_role.cloudsploit_cross_account_role-gov.arn}"
+  value = "${aws_iam_role.cloudsploit_cross_account_role-gov.*.arn}"
+
+  # enable output for this resource if we are using aws gov
+  count = "${var.use_aws_gov ? 1 : 0}"
 }

--- a/output.tf
+++ b/output.tf
@@ -1,3 +1,7 @@
 output "cloudsploit_cross_account_role_arn" {
   value = "${aws_iam_role.cloudsploit_cross_account_role.arn}"
 }
+
+output "cloudsploit_cross_account_role_arn-gov" {
+  value = "${aws_iam_role.cloudsploit_cross_account_role-gov.arn}"
+}

--- a/output.tf
+++ b/output.tf
@@ -1,13 +1,7 @@
 output "cloudsploit_cross_account_role_arn" {
   value = "${aws_iam_role.cloudsploit_cross_account_role.*.arn}"
-
-  # disable output for this resource if we are using aws gov
-  count = "${var.use_aws_gov ? 0 : 1}"
 }
 
 output "cloudsploit_cross_account_role_arn-gov" {
   value = "${aws_iam_role.cloudsploit_cross_account_role-gov.*.arn}"
-
-  # enable output for this resource if we are using aws gov
-  count = "${var.use_aws_gov ? 1 : 0}"
 }

--- a/variable.tf
+++ b/variable.tf
@@ -1,3 +1,8 @@
 variable "account_id" {}
 
 variable cloudsploit_external_id {}
+
+variable "use_aws_gov" {
+  default     = false
+  description = "This is used to toggle which role policy will be used, by default it assumes you are not in government cloud."
+}


### PR DESCRIPTION
This internally namespaces government and non government separately to avoid conflict. Also this introduces `use_aws_gov` which defaults to `false` so that its clear which TF resources will be created. As an account can't be both they are mutually exclusive and using `count` and some interpolation this is possible.

This should fix #2 

Signed-off-by: Ben Abrams <me@benabrams.it>