### PR TITLE
fix: Upgraded to Terraform v0.12

### DIFF
--- a/iam_cloudsploit_role.tf
+++ b/iam_cloudsploit_role.tf
@@ -2,7 +2,7 @@ resource "aws_iam_role" "cloudsploit_cross_account_role" {
   name = "tf-cloudsploit"
 
   # disable this if use_aws_gov == true
-  count = "${var.use_aws_gov ? 0 : 1}"
+  count = var.use_aws_gov ? 0 : 1
 
   assume_role_policy = <<EOF
 {
@@ -23,12 +23,14 @@ resource "aws_iam_role" "cloudsploit_cross_account_role" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_role_policy_attachment" "cloudsploit_cross_account_attach" {
   # disable this if use_aws_gov == true
-  count = "${var.use_aws_gov ? 0 : 1}"
+  count = var.use_aws_gov ? 0 : 1
 
-  role       = "${aws_iam_role.cloudsploit_cross_account_role.name}"
+  role = aws_iam_role.cloudsploit_cross_account_role[0].name
   policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
 }
+

--- a/iam_cloudsploit_role_gov.tf
+++ b/iam_cloudsploit_role_gov.tf
@@ -2,7 +2,7 @@ resource "aws_iam_role" "cloudsploit_cross_account_role-gov" {
   name = "tf-cloudsploit"
 
   # enable this if use_aws_gov == true
-  count = "${var.use_aws_gov ? 1 : 0}"
+  count = var.use_aws_gov ? 1 : 0
 
   assume_role_policy = <<EOF
 {
@@ -23,12 +23,14 @@ resource "aws_iam_role" "cloudsploit_cross_account_role-gov" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_role_policy_attachment" "cloudsploit_cross_account_attach-gov" {
   # enable this if use_aws_gov == true
-  count = "${var.use_aws_gov ? 1 : 0}"
+  count = var.use_aws_gov ? 1 : 0
 
-  role       = "${aws_iam_role.cloudsploit_cross_account_role-gov.name}"
+  role = aws_iam_role.cloudsploit_cross_account_role-gov[0].name
   policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
 }
+

--- a/output.tf
+++ b/output.tf
@@ -1,7 +1,8 @@
 output "cloudsploit_cross_account_role_arn" {
-  value = "${aws_iam_role.cloudsploit_cross_account_role.*.arn}"
+  value = aws_iam_role.cloudsploit_cross_account_role.*.arn
 }
 
 output "cloudsploit_cross_account_role_arn-gov" {
-  value = "${aws_iam_role.cloudsploit_cross_account_role-gov.*.arn}"
+  value = aws_iam_role.cloudsploit_cross_account_role-gov.*.arn
 }
+

--- a/variable.tf
+++ b/variable.tf
@@ -1,8 +1,11 @@
-variable "account_id" {}
+variable "account_id" {
+}
 
-variable cloudsploit_external_id {}
+variable "cloudsploit_external_id" {
+}
 
 variable "use_aws_gov" {
   default     = false
   description = "This is used to toggle which role policy will be used, by default it assumes you are not in government cloud."
 }
+


### PR DESCRIPTION
Not sure how you folks want to handle this, but TF 0.12 has some syntax changes that are unfortunately not backwards compatible. 

An idea is to have a branch on the main repo and eventually merge once TF v0.12 is a bit more widely accepted? :) The way we handle it internally is we always pin to a release version based on Git Tag. Not sure if that is an option for you and your customers as I didn't notice if the docs pinned on tag! :)

Open for discussion.