### PR TITLE
CloudSploit Supplemental Policy: TF v0.12

### DIFF
--- a/iam_cloudsploit_supplemental_policy.tf
+++ b/iam_cloudsploit_supplemental_policy.tf
@@ -1,0 +1,35 @@
+data "aws_iam_policy_document" "cloudsploit_supplemental_iam_policy" {
+  statement {
+    sid       = "CloudSploitSupplemental"
+    actions   = [
+        "athena:GetWorkGroup",
+        "cloudwatchlogs:DescribeLogGroups",
+        "cloudwatchlogs:DescribeMetricFilters",
+        "elastictranscoder:ListPipelines",
+        "ses:DescribeActiveReceiptRuleSet"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "cloudsploit_supplemental_iam_policy" {
+  name        = "cloudsploit-supplemental-policy"
+  description = "CloudSploit Supplemental IAM Policy for Additional Scans"
+  policy      = data.aws_iam_policy_document.cloudsploit_supplemental_iam_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "cloudsploit_supplemental_attach" {
+  # disable this if use_aws_gov == true
+  count = var.use_aws_gov ? 0 : 1
+
+  role = aws_iam_role.cloudsploit_cross_account_role[0].name
+  policy_arn = aws_iam_policy.cloudsploit_supplemental_iam_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "cloudsploit_supplemental_attach-gov" {
+  # enable this if use_aws_gov == true
+  count = var.use_aws_gov ? 1 : 0
+
+  role = aws_iam_role.cloudsploit_cross_account_role-gov[0].name
+  policy_arn = aws_iam_policy.cloudsploit_supplemental_iam_policy.arn
+}


### PR DESCRIPTION
Some additional CloudSploit scans require permissions that are not found on the default AWS SecurityAudit policy. To have feature parity with the CloudFormation template, adding support for the supplemental policy until AWS adds the resources in question to SecurityAudit policy.

I did remove an efs permission as this is actually in the Security Audit Policy by AWS under the proper name: elasticfilesystem

Only for Terraform v0.12