### PR TITLE
Use `[count.index]` to fix plan errors

### DIFF
--- a/iam_cloudsploit_role.tf
+++ b/iam_cloudsploit_role.tf
@@ -29,6 +29,6 @@ resource "aws_iam_role_policy_attachment" "cloudsploit_cross_account_attach" {
   # disable this if use_aws_gov == true
   count = "${var.use_aws_gov ? 0 : 1}"
 
-  role       = "${aws_iam_role.cloudsploit_cross_account_role.name}"
+  role       = "${aws_iam_role.cloudsploit_cross_account_role[count.index].name}"
   policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
 }

--- a/iam_cloudsploit_role_gov.tf
+++ b/iam_cloudsploit_role_gov.tf
@@ -29,6 +29,6 @@ resource "aws_iam_role_policy_attachment" "cloudsploit_cross_account_attach-gov"
   # enable this if use_aws_gov == true
   count = "${var.use_aws_gov ? 1 : 0}"
 
-  role       = "${aws_iam_role.cloudsploit_cross_account_role-gov.name}"
+  role       = "${aws_iam_role.cloudsploit_cross_account_role-gov[count.index].name}"
   policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
 }


### PR DESCRIPTION
When creating the plan with Terraform version: 0.12.9, the following errors were encountered:
```
Error: Missing resource instance key

  on .terraform/modules/cloudsploit/iam_cloudsploit_role.tf line 32, in resource "aws_iam_role_policy_attachment" "cloudsploit_cross_account_attach":
  32:   role       = "${aws_iam_role.cloudsploit_cross_account_role.name}"

Because aws_iam_role.cloudsploit_cross_account_role has "count" set, its
attributes must be accessed on specific instances.

For example, to correlate with indices of a referring resource, use:
    aws_iam_role.cloudsploit_cross_account_role[count.index]


Error: Missing resource instance key

  on .terraform/modules/cloudsploit/iam_cloudsploit_role_gov.tf line 32, in resource "aws_iam_role_policy_attachment" "cloudsploit_cross_account_attach-gov":
  32:   role       = "${aws_iam_role.cloudsploit_cross_account_role-gov.name}"

Because aws_iam_role.cloudsploit_cross_account_role-gov has "count" set, its
attributes must be accessed on specific instances.

For example, to correlate with indices of a referring resource, use:
    aws_iam_role.cloudsploit_cross_account_role-gov[count.index]
```

This pull request fixes the attribute reference by using `[count.index]` per the error's suggestion.