### PR TITLE
terraform 0.12 syntax deprecation cleanup

### DIFF
--- a/iam_cloudsploit_role.tf
+++ b/iam_cloudsploit_role.tf
@@ -2,7 +2,7 @@ resource "aws_iam_role" "cloudsploit_cross_account_role" {
   name = "tf-cloudsploit"
 
   # disable this if use_aws_gov == true
-  count = "${var.use_aws_gov ? 0 : 1}"
+  count = var.use_aws_gov ? 0 : 1
 
   assume_role_policy = <<EOF
 {
@@ -27,8 +27,8 @@ EOF
 
 resource "aws_iam_role_policy_attachment" "cloudsploit_cross_account_attach" {
   # disable this if use_aws_gov == true
-  count = "${var.use_aws_gov ? 0 : 1}"
+  count = var.use_aws_gov ? 0 : 1
 
-  role       = "${aws_iam_role.cloudsploit_cross_account_role.name}"
+  role       = aws_iam_role.cloudsploit_cross_account_role.name
   policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
 }

--- a/iam_cloudsploit_role_gov.tf
+++ b/iam_cloudsploit_role_gov.tf
@@ -2,7 +2,7 @@ resource "aws_iam_role" "cloudsploit_cross_account_role-gov" {
   name = "tf-cloudsploit"
 
   # enable this if use_aws_gov == true
-  count = "${var.use_aws_gov ? 1 : 0}"
+  count = var.use_aws_gov ? 1 : 0
 
   assume_role_policy = <<EOF
 {
@@ -27,8 +27,8 @@ EOF
 
 resource "aws_iam_role_policy_attachment" "cloudsploit_cross_account_attach-gov" {
   # enable this if use_aws_gov == true
-  count = "${var.use_aws_gov ? 1 : 0}"
+  count = var.use_aws_gov ? 1 : 0
 
-  role       = "${aws_iam_role.cloudsploit_cross_account_role-gov.name}"
+  role       = aws_iam_role.cloudsploit_cross_account_role-gov.name
   policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
 }

--- a/output.tf
+++ b/output.tf
@@ -1,7 +1,7 @@
 output "cloudsploit_cross_account_role_arn" {
-  value = "${aws_iam_role.cloudsploit_cross_account_role.*.arn}"
+  value = aws_iam_role.cloudsploit_cross_account_role.*.arn
 }
 
 output "cloudsploit_cross_account_role_arn-gov" {
-  value = "${aws_iam_role.cloudsploit_cross_account_role-gov.*.arn}"
+  value = aws_iam_role.cloudsploit_cross_account_role-gov.*.arn
 }

--- a/version_constraints.tf
+++ b/version_constraints.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = ">= 0.12"
+  # TODO: lock on min AWS module?
+  # requiredd_providers {
+  #   aws = ">= x.y.x"
+  # }
+}


### PR DESCRIPTION
This removes places where prior to 0.12 you were required to wrap variables and expressions and use interpolation. This is no longer needed.

NOTE: this will break any systems using 0.12 as such we have included in the repo a min version this module requires. People still needing < 0.12 support can pin via git to a previous version.

Signed-off-by: Ben Abrams <me@benabrams.it>