### PR TITLE
add count.index to role

### DIFF
--- a/iam_cloudsploit_role.tf
+++ b/iam_cloudsploit_role.tf
@@ -29,6 +29,6 @@ resource "aws_iam_role_policy_attachment" "cloudsploit_cross_account_attach" {
   # disable this if use_aws_gov == true
   count = "${var.use_aws_gov ? 0 : 1}"
 
-  role       = "${aws_iam_role.cloudsploit_cross_account_role.name}"
+  role       = "${aws_iam_role.cloudsploit_cross_account_role[count.index].name}"
   policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
 }


### PR DESCRIPTION
Solves the following error:
Error: Missing resource instance key
│ 
│   on .terraform/modules/cloudsploit/iam_cloudsploit_role.tf line 32, in resource "aws_iam_role_policy_attachment" "cloudsploit_cross_account_attach":
│   32:   role       = "${aws_iam_role.cloudsploit_cross_account_role.name}"
│ 
│ Because aws_iam_role.cloudsploit_cross_account_role has "count" set, its attributes must be accessed on specific instances.
│ 
│ For example, to correlate with indices of a referring resource, use:
│     aws_iam_role.cloudsploit_cross_account_role[count.index]