### PR TITLE
Remove Explicit AWS Provider

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -6,7 +6,3 @@ terraform {
     }
   }
 }
-
-provider "aws" {
-  region = "us-east-1"
-}


### PR DESCRIPTION
An AWS provider is explicitly set in this module, which overrides any custom provider configuration a user may use in their root module.

The child module (this one) should use the root module's provider information or an explicitly passed in provider (see [Passing Providers Explicitly](https://www.terraform.io/language/modules/develop/providers#passing-providers-explicitly)) .

Reasons you would want to use the provider from root include but are not limited to using a different region than "us-east-1" and/or using an "assume role" within the root provider block.

Since this provider is explicitly set here, it can not be overwritten.